### PR TITLE
Faster performance with `numba`

### DIFF
--- a/heisenberg_2d.py
+++ b/heisenberg_2d.py
@@ -1,5 +1,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
+from numba import njit
 
 np.random.seed(444222)
 
@@ -10,6 +11,7 @@ def initialize(N):
 
 
 ## metropolis-hastings step to determine a random spin to flip and see if the flip is valid
+@njit(fastmath=True)
 def metropolis(grid, beta, H):
     N = grid.shape[0]
     for _ in range(N * N):
@@ -27,6 +29,7 @@ def metropolis(grid, beta, H):
 
 
 ## compute the energy of the current spin configuration
+@njit(fastmath=True)
 def energy(grid, H):
     E = 0
     N = grid.shape[0]
@@ -37,6 +40,7 @@ def energy(grid, H):
     return 1.0 * E / 4  ## avoid overcounting
 
 
+@njit(fastmath=True)
 def magnetization(grid):
     return np.sum(grid)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy
 pandas
+numba
 matplotlib
 pylint
 pytest


### PR DESCRIPTION
Uses [`@njit` annotation from numba](https://numba.pydata.org/numba-doc/latest/user/performance-tips.html) to improve computation performance. The Metropolis algorithm should easily work with this.