### PR TITLE
Fix notebook failing in CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+ipywidgets
 matplotlib
 nbval
 numba


### PR DESCRIPTION
Add `ipywidgets` so that tqdm.notebook can run